### PR TITLE
Feat(auth-manager): add case-manager restriction

### DIFF
--- a/infrastructure/authorization-manager/stage/README.md
+++ b/infrastructure/authorization-manager/stage/README.md
@@ -15,9 +15,13 @@ The current stack deploys AWS Verified Permissions, defining an identity source 
   latest token containing the proper Cognito group claims for it to work. This also applies when a user is removed from
   the group; the JWT must expire to become invalid.
 
+  The identity source is restricted to the platform's known Cognito app client IDs
+  (`clientIdParameterNames` in `config.ts`) — tokens minted by other app clients registered
+  under the same user pool are not accepted.
+
 ### Group
 
-Policies are currently assigned based on groups from the Cognito User Pool. The policies are defined in `stack.ts` within the class where the function is named `setup{GROUP_NAME}CedarPolicy`.
+Policies are currently assigned based on groups from the Cognito User Pool. The policies are defined as data in the `GROUP_POLICIES` array in `stack.ts`, and turned into Cedar `CfnPolicy` resources by `setupGroupPolicies`.
 
 - **Admin**: For admins/service users (all actions are granted to this group).
 - **Curators**: For curators (all policies are applied to all curators in this group).
@@ -29,5 +33,17 @@ Policies are currently assigned based on groups from the Cognito User Pool. The 
 | ------------------------------------------------------------------------------------------------- | ------------------ | ------------------ |
 | Allow rerun workflows in the WORKFLOW microservice                                                | :white_check_mark: | :white_check_mark: |
 | Allow to sync external metadata in the METADATA microservice                                      | :x:                | :white_check_mark: |
+| Allow to link external entities to a case in the CASE microservice                                | :white_check_mark: | :white_check_mark: |
+| Allow to unlink external entities from a case in the CASE microservice                            | :white_check_mark: | :white_check_mark: |
 
 `Admin` group will have a wildcard to allow all actions.
+
+NOTE: Please update this table if `GROUP_POLICIES` in `stack.ts` is modified.
+
+### HTTP Lambda Authorizer
+
+The Lambda authorizer maps each request into Cedar terms — the identity token as the
+principal, the route (e.g. `POST /api/v1/workflowrun/{orcabusId}/rerun/{proxy+}`) as the
+action, and the API's domain prefix, uppercased (e.g. `workflow.umccr.org` → `WORKFLOW`), as
+the `OrcaBus::Microservice` resource — then calls AVP's `IsAuthorizedWithToken` to decide
+whether to allow the request.

--- a/infrastructure/authorization-manager/stage/cedarSchema.json
+++ b/infrastructure/authorization-manager/stage/cedarSchema.json
@@ -12,6 +12,18 @@
           "principalTypes": ["User", "CognitoUserGroup"],
           "resourceTypes": ["Microservice"]
         }
+      },
+      "POST /api/v1/case/{orcabusId}/external-entity/{PROXY+}": {
+        "appliesTo": {
+          "principalTypes": ["User", "CognitoUserGroup"],
+          "resourceTypes": ["Microservice"]
+        }
+      },
+      "DELETE /api/v1/case/{orcabusId}/external-entity/{externalEntityOrcabusId}/{PROXY+}": {
+        "appliesTo": {
+          "principalTypes": ["User", "CognitoUserGroup"],
+          "resourceTypes": ["Microservice"]
+        }
       }
     },
     "entityTypes": {

--- a/infrastructure/authorization-manager/stage/config.ts
+++ b/infrastructure/authorization-manager/stage/config.ts
@@ -5,6 +5,7 @@ import {
 import { AuthorizationManagerStackProps } from './stack';
 import {
   AUTH_STACK_HTTP_LAMBDA_AUTHORIZER_PARAMETER_NAME,
+  COGNITO_CLIENT_ID_PARAMETER_NAME_ARRAY,
   DEFAULT_COGNITO_USER_POOL_ID_PARAMETER_NAME,
 } from '@orcabus/platform-cdk-constructs/api-gateway';
 import { REGION } from '@orcabus/platform-cdk-constructs/shared-config/accounts';
@@ -17,6 +18,7 @@ export const getAuthorizationManagerStackProps = (
       userPoolIdParameterName: DEFAULT_COGNITO_USER_POOL_ID_PARAMETER_NAME,
       region: REGION,
       accountNumber: ACCOUNT_ID_ALIAS[stage],
+      clientIdParameterNames: COGNITO_CLIENT_ID_PARAMETER_NAME_ARRAY[stage],
     },
     authStackHttpLambdaAuthorizerParameterName: AUTH_STACK_HTTP_LAMBDA_AUTHORIZER_PARAMETER_NAME,
   };

--- a/infrastructure/authorization-manager/stage/http-lambda-authorizer/http_authorizer.py
+++ b/infrastructure/authorization-manager/stage/http-lambda-authorizer/http_authorizer.py
@@ -1,5 +1,9 @@
+import logging
 import os
 import boto3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
 client = boto3.client('verifiedpermissions')
 
@@ -45,9 +49,8 @@ def handler(event, context):
         "isAuthorized": False,
     }
 
-    auth_token = event["headers"]["authorization"]
-
     try:
+        auth_token = event.get("headers", {}).get("authorization")
 
         if auth_token:
 
@@ -56,17 +59,28 @@ def handler(event, context):
 
             entityType = event.get("requestContext", {}).get("domainPrefix", "")
             routeKey = event.get("routeKey", "")
+            resourceEntityId = entityType.upper()
+
+            # entityType is derived from the API's custom domain subdomain prefix
+            # (see README for the DNS-to-microservice-name coupling this relies on).
+            # Logged so a mismatch (e.g. a renamed domain) is traceable rather than
+            # silently resolving to a deny.
+            logger.info(
+                "Checking authorization for action=%s resource=OrcaBus::Microservice::%s",
+                routeKey,
+                resourceEntityId,
+            )
 
             avp_response = client.is_authorized_with_token(
                 policyStoreId=os.environ.get("POLICY_STORE_ID"),
                 identityToken=auth_token,
                 action={
-                    "actionType": f"OrcaBus::Action",
+                    "actionType": "OrcaBus::Action",
                     "actionId": routeKey,
                 },
                 resource={
                     "entityType": "OrcaBus::Microservice",
-                    "entityId": entityType.upper(),
+                    "entityId": resourceEntityId,
                 },
             )
 
@@ -75,6 +89,6 @@ def handler(event, context):
             }
         else:
             return response
-    except BaseException as e:
-        print("ERROR: ", e)
+    except Exception as e:
+        logger.error("ERROR: %s", e)
         return response

--- a/infrastructure/authorization-manager/stage/stack.ts
+++ b/infrastructure/authorization-manager/stage/stack.ts
@@ -14,6 +14,59 @@ export interface AuthorizationManagerStackProps {
   authStackHttpLambdaAuthorizerParameterName: string;
 }
 
+/**
+ * Describes a static Cedar policy that grants a Cognito user group access to a
+ * set of actions on a microservice resource.
+ *
+ * NOTE: Please update README.md's permissions table if this list is modified.
+ *
+ * `id` is the CDK/CloudFormation logical id for the underlying CfnPolicy and
+ * must stay stable across reordering/edits to avoid resource replacement.
+ */
+interface CedarGroupPolicy {
+  id: string;
+  /** One or more Cognito group names. Each group gets its own CfnPolicy. */
+  groups: string[];
+  description: string;
+  actions?: string[];
+  resource?: string;
+}
+
+const GROUP_POLICIES: CedarGroupPolicy[] = [
+  {
+    id: 'CognitoPortalAdminPolicy',
+    groups: ['admin'],
+    description: 'Allow all actions on all resources',
+  },
+  // WORKFLOW resource
+  {
+    id: 'CognitoWorkflowRerunPolicy',
+    groups: ['curators', 'bioinfo'],
+    description: 'Permissions to rerun workflowrun in WORKFLOW microservice',
+    actions: ['POST /api/v1/workflowrun/{orcabusId}/rerun/{proxy+}'],
+    resource: 'WORKFLOW',
+  },
+  // METADATA resource
+  {
+    id: 'CognitoBioinfoMetadataModifyPolicy',
+    groups: ['bioinfo'],
+    description: 'Permissions to trigger external sync in METADATA microservice',
+    actions: ['POST /api/v1/sync/presigned-csv/{PROXY+}'],
+    resource: 'METADATA',
+  },
+  // CASE resource
+  {
+    id: 'CognitoCaseEntityLinkModifyPolicy',
+    groups: ['curators', 'bioinfo'],
+    description: 'Permissions to manage case external entity links in CASE microservice',
+    actions: [
+      'POST /api/v1/case/{orcabusId}/external-entity/{PROXY+}',
+      'DELETE /api/v1/case/{orcabusId}/external-entity/{externalEntityOrcabusId}/{PROXY+}',
+    ],
+    resource: 'CASE',
+  },
+];
+
 interface CognitoConfig {
   /**
    * The SSM parameter name that cognito user pool ID is stored
@@ -27,6 +80,13 @@ interface CognitoConfig {
    * The AWS account number where the cognito user pool is deployed
    */
   accountNumber: string;
+  /**
+   * SSM parameter names holding the app client IDs allowed to mint tokens
+   * that this policy store will accept. Restricts the identity source so
+   * tokens from unrelated Cognito app clients under the same user pool
+   * are not implicitly trusted.
+   */
+  clientIdParameterNames: string[];
 }
 
 export class AuthorizationManagerStack extends Stack {
@@ -61,16 +121,8 @@ export class AuthorizationManagerStack extends Stack {
       authStackHttpLambdaAuthorizerParameterName: props.authStackHttpLambdaAuthorizerParameterName,
     });
 
-    // Create a policies for respective groups
-    this.setupAdminCedarPolicy({
-      userPoolId,
-      cfnPolicyStore: policyStore,
-    });
-    this.setupCuratorsCedarPolicy({
-      userPoolId,
-      cfnPolicyStore: policyStore,
-    });
-    this.setupBioinfoCedarPolicy({
+    // Create policies for respective groups, defined in GROUP_POLICIES
+    this.setupGroupPolicies({
       userPoolId,
       cfnPolicyStore: policyStore,
     });
@@ -88,11 +140,23 @@ export class AuthorizationManagerStack extends Stack {
     policyStoreId: string;
     cognito: CognitoConfig;
   }) {
+    // Restrict accepted tokens to the platform's known app clients, rather than
+    // implicitly trusting any app client registered under the user pool.
+    const clientIds = props.cognito.clientIdParameterNames.map(
+      (parameterName) =>
+        StringParameter.fromStringParameterName(
+          this,
+          `CognitoAppClientIdStringParameter${parameterName}`,
+          parameterName
+        ).stringValue
+    );
+
     // Allow the policy store to source the identity from existing Cognito User Pool Id
     new CfnIdentitySource(this, 'VerifiedPermissionIdentitySource', {
       configuration: {
         cognitoUserPoolConfiguration: {
           userPoolArn: `arn:aws:cognito-idp:${props.cognito.region}:${props.cognito.accountNumber}:userpool/${props.userPoolId}`,
+          clientIds,
           groupConfiguration: {
             groupEntityType: 'OrcaBus::CognitoUserGroup', // Refer to './cedarSchema.json'
           },
@@ -132,13 +196,13 @@ export class AuthorizationManagerStack extends Stack {
   }
 
   /**
-   * This sets up all policies for the admin group in the Cognito user pool.
+   * Creates one CfnPolicy per entry in GROUP_POLICIES.
    *
-   * NOTE: Please update readme if new policy is modified
+   * NOTE: Please update README.md's permissions table if GROUP_POLICIES is modified.
    * @param userPoolId
    * @param cfnPolicyStore
    */
-  private setupAdminCedarPolicy({
+  private setupGroupPolicies({
     userPoolId,
     cfnPolicyStore,
   }: {
@@ -147,114 +211,36 @@ export class AuthorizationManagerStack extends Stack {
   }) {
     const policyStoreId = cfnPolicyStore.attrPolicyStoreId;
 
-    // 1. Policy to allow everything for the admin group
-    const allowAllPolicy = new CfnPolicy(this, 'CognitoPortalAdminPolicy', {
-      definition: {
-        static: {
-          statement: `
-            permit (
-              principal in OrcaBus::CognitoUserGroup::"${userPoolId}|admin",
-              action,
-              resource
-            );
-          `,
-          description: 'admin - Allow all action for all resource for the admin cognito group',
-        },
-      },
-      policyStoreId: policyStoreId,
-    });
-    allowAllPolicy.node.addDependency(cfnPolicyStore);
-  }
+    for (const policyDef of GROUP_POLICIES) {
+      for (const group of policyDef.groups) {
+        // When multiple groups share a policy entry, suffix the CDK logical ID with the group
+        // name to keep IDs unique and stable.
+        const cfnId = `${policyDef.id}${group.charAt(0).toUpperCase()}${group.slice(1)}`;
 
-  /**
-   * This sets up all policies for the curators group in the Cognito user pool.
-   *
-   * NOTE: Please update readme if new policy is modified
-   * @param userPoolId
-   * @param cfnPolicyStore
-   */
-  private setupCuratorsCedarPolicy({
-    userPoolId,
-    cfnPolicyStore,
-  }: {
-    userPoolId: string;
-    cfnPolicyStore: CfnPolicyStore;
-  }) {
-    const policyStoreId = cfnPolicyStore.attrPolicyStoreId;
+        const principal = `OrcaBus::CognitoUserGroup::"${userPoolId}|${group}"`;
+        const actionResourceClause = policyDef.actions
+          ? `action in
+                [${policyDef.actions.map((action) => `OrcaBus::Action::"${action}"`).join(', ')}],
+              resource == OrcaBus::Microservice::"${policyDef.resource}"`
+          : `action,
+              resource`;
 
-    // 1. Policy to allow rerun workflows in the WORKFLOW microservice
-    const allowRerunPolicy = new CfnPolicy(this, 'CognitoPortalCuratorsPolicy', {
-      definition: {
-        static: {
-          statement: `
-            permit (
-              principal in OrcaBus::CognitoUserGroup::"${userPoolId}|curators",
-              action in
-                [OrcaBus::Action::"POST /api/v1/workflowrun/{orcabusId}/rerun/{proxy+}"],
-              resource == OrcaBus::Microservice::"WORKFLOW"
-            );
-          `,
-          description: 'curators - Permissions to rerun workflowrun in WORKFLOW microservice',
-        },
-      },
-      policyStoreId: policyStoreId,
-    });
-    allowRerunPolicy.node.addDependency(cfnPolicyStore);
-  }
-
-  /**
-   * This sets up all policies for the curators group in the Cognito user pool.
-   *
-   * NOTE: Please update readme if new policy is modified
-   * @param userPoolId
-   * @param cfnPolicyStore
-   */
-  private setupBioinfoCedarPolicy({
-    userPoolId,
-    cfnPolicyStore,
-  }: {
-    userPoolId: string;
-    cfnPolicyStore: CfnPolicyStore;
-  }) {
-    const policyStoreId = cfnPolicyStore.attrPolicyStoreId;
-    const principal = `OrcaBus::CognitoUserGroup::"${userPoolId}|bioinfo"`;
-
-    // 1. Policy to allow rerun workflows in the WORKFLOW microservice
-    const allowRerunPolicy = new CfnPolicy(this, 'CognitoBioinfoWorkflowRerunPolicy', {
-      definition: {
-        static: {
-          statement: `
+        const cfnPolicy = new CfnPolicy(this, cfnId, {
+          definition: {
+            static: {
+              statement: `
             permit (
               principal in ${principal},
-              action in
-                [OrcaBus::Action::"POST /api/v1/workflowrun/{orcabusId}/rerun/{proxy+}"],
-              resource == OrcaBus::Microservice::"WORKFLOW"
+              ${actionResourceClause}
             );
           `,
-          description: 'bioinfo - Permissions to rerun workflowrun in WORKFLOW microservice',
-        },
-      },
-      policyStoreId: policyStoreId,
-    });
-    allowRerunPolicy.node.addDependency(cfnPolicyStore);
-
-    // 2. Policy to trigger external sync in METADATA microservice
-    const allowModifyMetadataPolicy = new CfnPolicy(this, 'CognitoBioinfoMetadataModifyPolicy', {
-      definition: {
-        static: {
-          statement: `
-            permit (
-              principal in ${principal},
-              action in
-                [OrcaBus::Action::"POST /api/v1/sync/presigned-csv/{PROXY+}"],
-              resource == OrcaBus::Microservice::"METADATA"
-            );
-          `,
-          description: 'bioinfo - Permissions to trigger external sync METADATA microservice',
-        },
-      },
-      policyStoreId: policyStoreId,
-    });
-    allowModifyMetadataPolicy.node.addDependency(cfnPolicyStore);
+              description: policyDef.description,
+            },
+          },
+          policyStoreId: policyStoreId,
+        });
+        cfnPolicy.node.addDependency(cfnPolicyStore);
+      }
+    }
   }
 }


### PR DESCRIPTION
- add case manager external-entity as a resource for AVP
- only allow `bioinfo` and `curator` lists to execute case-manager linking libraries/wfr API
- add configuration to only allow orcabus cognito-app-client for the AVP